### PR TITLE
[Issue#53] profile 에 따른 github oauth client 사용하도록 변경

### DIFF
--- a/src/main/kotlin/com/ixfp/gitmon/GitmonApplication.kt
+++ b/src/main/kotlin/com/ixfp/gitmon/GitmonApplication.kt
@@ -1,11 +1,13 @@
 package com.ixfp.gitmon
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.cloud.openfeign.EnableFeignClients
 
 @SpringBootApplication
 @EnableFeignClients
+@ConfigurationPropertiesScan
 class GitmonApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/ixfp/gitmon/client/github/GithubApiService.kt
+++ b/src/main/kotlin/com/ixfp/gitmon/client/github/GithubApiService.kt
@@ -4,10 +4,10 @@ import com.ixfp.gitmon.client.github.request.GithubAccessTokenRequest
 import com.ixfp.gitmon.client.github.request.GithubUpsertFileRequest
 import com.ixfp.gitmon.client.github.response.GithubContent
 import com.ixfp.gitmon.client.github.response.GithubUserResponse
+import com.ixfp.gitmon.common.type.Profile
 import com.ixfp.gitmon.common.util.Base64Encoder
 import com.ixfp.gitmon.common.util.BearerToken
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
 
@@ -15,20 +15,30 @@ import org.springframework.web.multipart.MultipartFile
 class GithubApiService(
     private val githubOauth2ApiClient: GithubOauth2ApiClient,
     private val githubResourceApiClient: GithubResourceApiClient,
-    @Value("\${oauth2.client.github.id}") private val githubClientId: String,
-    @Value("\${oauth2.client.github.secret}") private val githubClientSecret: String,
+    private val githubProdClient: GithubOauth2ClientProdProperties,
+    private val githubDevClient: GithubOauth2ClientDevProperties,
 ) {
     fun getGithubUser(githubAccessToken: String): GithubUserResponse {
         return githubResourceApiClient.fetchUser(BearerToken(githubAccessToken).format())
     }
 
-    fun getAccessTokenByCode(code: String): String {
-        log.info { "GithubApiService#getAccessTokenByCode start. code=$code" }
+    fun getAuthRedirectionUrl(profile: Profile): String {
+        return when (profile) {
+            Profile.PROD -> buildAuthRedirectionUrl(githubProdClient.id)
+            Profile.DEV -> buildAuthRedirectionUrl(githubDevClient.id)
+        }
+    }
+
+    fun getAccessTokenByCode(
+        code: String,
+        profile: Profile,
+    ): String {
+        log.info { "GithubApiService#getAccessTokenByCode start. code=$code, profile=$profile" }
         val request =
             GithubAccessTokenRequest(
                 code = code,
-                client_id = githubClientId,
-                client_secret = githubClientSecret,
+                client_id = githubClientId(profile),
+                client_secret = githubClientSecret(profile),
             )
         val response = githubOauth2ApiClient.fetchAccessToken(request)
         log.info { "GithubApiService#getAccessTokenByCode end. response=$response" }
@@ -62,6 +72,24 @@ class GithubApiService(
             )
 
         return response.content
+    }
+
+    private fun buildAuthRedirectionUrl(githubClientId: String): String {
+        return "https://github.com/login/oauth/authorize?&scope=repo&client_id=$githubClientId"
+    }
+
+    private fun githubClientId(profile: Profile): String {
+        return when (profile) {
+            Profile.PROD -> githubProdClient.id
+            Profile.DEV -> githubDevClient.id
+        }
+    }
+
+    private fun githubClientSecret(profile: Profile): String {
+        return when (profile) {
+            Profile.PROD -> githubProdClient.secret
+            Profile.DEV -> githubDevClient.secret
+        }
     }
 
     companion object {

--- a/src/main/kotlin/com/ixfp/gitmon/client/github/GithubOauth2ClientDevProperties.kt
+++ b/src/main/kotlin/com/ixfp/gitmon/client/github/GithubOauth2ClientDevProperties.kt
@@ -1,0 +1,9 @@
+package com.ixfp.gitmon.client.github
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "oauth2.client-dev.github")
+data class GithubOauth2ClientDevProperties(
+    val id: String,
+    val secret: String,
+)

--- a/src/main/kotlin/com/ixfp/gitmon/client/github/GithubOauth2ClientProdProperties.kt
+++ b/src/main/kotlin/com/ixfp/gitmon/client/github/GithubOauth2ClientProdProperties.kt
@@ -1,0 +1,9 @@
+package com.ixfp.gitmon.client.github
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "oauth2.client.github")
+data class GithubOauth2ClientProdProperties(
+    val id: String,
+    val secret: String,
+)

--- a/src/main/kotlin/com/ixfp/gitmon/common/type/Profile.kt
+++ b/src/main/kotlin/com/ixfp/gitmon/common/type/Profile.kt
@@ -1,0 +1,13 @@
+package com.ixfp.gitmon.common.type
+
+enum class Profile(val code: String, val description: String) {
+    DEV("dev", "개발환경"),
+    PROD("prod", "운영환경"),
+    ;
+
+    companion object {
+        fun findByCode(code: String?): Profile {
+            return entries.find { it.code == code } ?: PROD
+        }
+    }
+}

--- a/src/main/kotlin/com/ixfp/gitmon/controller/IOauth2Controller.kt
+++ b/src/main/kotlin/com/ixfp/gitmon/controller/IOauth2Controller.kt
@@ -29,7 +29,7 @@ interface IOauth2Controller {
             ),
         ],
     )
-    fun redirectToGithubOauthUrl(): ResponseEntity<Unit>
+    fun redirectToGithubOauthUrl(profile: String?): ResponseEntity<Unit>
 
     @Operation(
         summary = "gitmon Access 토큰 발급",
@@ -60,5 +60,8 @@ interface IOauth2Controller {
             // TODO: 깃허브 API 에러로 인한 에러 응답 예제 추가
         ],
     )
-    fun login(request: GithubOauth2Request): com.ixfp.gitmon.common.type.ApiResponse<AccessTokenResponse>
+    fun login(
+        profile: String?,
+        request: GithubOauth2Request,
+    ): com.ixfp.gitmon.common.type.ApiResponse<AccessTokenResponse>
 }

--- a/src/main/kotlin/com/ixfp/gitmon/controller/Oauth2Controller.kt
+++ b/src/main/kotlin/com/ixfp/gitmon/controller/Oauth2Controller.kt
@@ -3,41 +3,44 @@ package com.ixfp.gitmon.controller
 import com.ixfp.gitmon.client.github.GithubApiService
 import com.ixfp.gitmon.common.type.ApiErrorType
 import com.ixfp.gitmon.common.type.ApiResponse
+import com.ixfp.gitmon.common.type.Profile
 import com.ixfp.gitmon.controller.request.GithubOauth2Request
 import com.ixfp.gitmon.controller.response.AccessTokenResponse
 import com.ixfp.gitmon.domain.auth.AuthService
 import io.github.oshai.kotlinlogging.KotlinLogging.logger
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import javax.naming.AuthenticationException
 
 @RestController
 @RequestMapping("/api/v1")
 class Oauth2Controller(
-    @Value("\${oauth2.client.github.id}") private val githubClientId: String,
     private val authService: AuthService,
     private val githubApiService: GithubApiService,
 ) : IOauth2Controller {
     @GetMapping("/login/oauth/github")
-    override fun redirectToGithubOauthUrl(): ResponseEntity<Unit> {
+    override fun redirectToGithubOauthUrl(profile: String?): ResponseEntity<Unit> {
+        val redirectionUrl = githubApiService.getAuthRedirectionUrl(Profile.findByCode(profile))
+
         return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).header(
             "Location",
-            "https://github.com/login/oauth/authorize?&scope=repo&client_id=$githubClientId",
+            redirectionUrl,
         ).build()
     }
 
     @PostMapping("/login/oauth/github/tokens")
     override fun login(
+        @RequestParam profile: String?,
         @RequestBody request: GithubOauth2Request,
     ): ApiResponse<AccessTokenResponse> {
         try {
-            val githubAccessToken = githubApiService.getAccessTokenByCode(request.code)
+            val githubAccessToken = githubApiService.getAccessTokenByCode(request.code, Profile.findByCode(profile))
             val githubUser = githubApiService.getGithubUser(githubAccessToken)
             val member =
                 authService.getMemberByGithubId(githubUser.id.toLong())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,8 +21,12 @@ spring:
 oauth2:
   client:
     github:
-      id: ${OAUTH2_CLIENT_GITHUB_ID}
-      secret: ${OAUTH2_CLIENT_GITHUB_SECRET}
+      id: ${GITHUB_OAUTH2_CLIENT_ID_PROD}
+      secret: ${GITHUB_OAUTH2_CLIENT_SECRET_PROD}
+  client-dev:
+    github:
+      id: ${GITHUB_OAUTH2_CLIENT_ID_DEV}
+      secret: ${GITHUB_OAUTH2_CLIENT_SECRET_DEV}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,6 +18,10 @@ oauth2:
     github:
       id: 'id'
       secret: 'secret'
+  client-dev:
+    github:
+      id: 'id'
+      secret: 'dev'
 
 jwt:
   secret: 'jwt_secret_key_with_size_greater_than_256_bits'


### PR DESCRIPTION
Oauth2Controller 의 2개 API 에 영향
- /api/v1/login/oauth/github (깃허브 인증 페이지로 redirect)
- /api/v1/login/oauth/github/tokens (백엔드에서 깃허브 인증 후, 자체 액세스 토큰 발급)

API 요청시 파라미터로 profile 값을 넘겨준다.
- `profile=dev` : 개발용 github oauth app 호출, 인증 성공시 http://localhost:3000/auth/callback 으로 리다이렉트
- `profile=prod` 또는 `profile=null`(값 없음) : 운영용 github oauth app 호출, 인증 성공시 https://gitmon.blog/auth/callback 으로 리다이렉트